### PR TITLE
Fix base template loading

### DIFF
--- a/apps/clientes/templates/clientes/cadastrar.html
+++ b/apps/clientes/templates/clientes/cadastrar.html
@@ -1,4 +1,4 @@
-{% extends 'base.html' %}
+{% extends 'core/base.html' %}
 {% block content %}
 <h2>Cadastrar Cliente</h2>
 <form method="post" enctype="multipart/form-data">

--- a/apps/clientes/templates/clientes/listar.html
+++ b/apps/clientes/templates/clientes/listar.html
@@ -1,4 +1,4 @@
-{% extends 'base.html' %}
+{% extends 'core/base.html' %}
 {% block content %}
 <h2>Clientes Cadastrados</h2>
 <a href="{% url 'cadastrar_cliente' %}" class="btn btn-success">Novo Cliente</a>

--- a/apps/clientes/templates/clientes/visualizar.html
+++ b/apps/clientes/templates/clientes/visualizar.html
@@ -1,4 +1,4 @@
-{% extends 'base.html' %}
+{% extends 'core/base.html' %}
 {% block content %}
 <h2>{{ cliente.nome }}</h2>
 <p>Email: {{ cliente.email }}</p>

--- a/apps/core/apps.py
+++ b/apps/core/apps.py
@@ -3,4 +3,5 @@ from django.apps import AppConfig
 
 class CoreConfig(AppConfig):
     default_auto_field = 'django.db.models.BigAutoField'
-    name = 'core'
+    # Use the full dotted path so Django can correctly locate the app
+    name = 'apps.core'

--- a/apps/core/templates/core/base.html
+++ b/apps/core/templates/core/base.html
@@ -8,7 +8,7 @@
 <body class="container mt-4">
   <h1 class="mb-4">RL Construções Elétricas</h1>
   <nav class="mb-4">
-    <a href="/static" class="btn btn-outline-dark">Clientes</a>
+    <a href="{% url 'clientes:listar_clientes' %}" class="btn btn-outline-dark">Clientes</a>
     <a href="/financeiro/" class="btn btn-outline-dark">Financeiro</a>
   </nav>
   {% block content %}{% endblock %}

--- a/apps/financeiro/templates/financeiro/cadastrar.html
+++ b/apps/financeiro/templates/financeiro/cadastrar.html
@@ -1,4 +1,4 @@
-{% extends 'base.html' %}
+{% extends 'core/base.html' %}
 {% block content %}
 <h2>Cadastrar Conta</h2>
 <form method="post">

--- a/apps/financeiro/templates/financeiro/listar.html
+++ b/apps/financeiro/templates/financeiro/listar.html
@@ -1,4 +1,4 @@
-{% extends 'base.html' %}
+{% extends 'core/base.html' %}
 {% block content %}
 <h2>Contas a Pagar e Receber</h2>
 <a href="{% url 'cadastrar_conta' %}" class="btn btn-primary">Nova Conta</a>


### PR DESCRIPTION
## Summary
- fix CoreConfig path so Django can load the app
- link Clientes button correctly in base template
- reference core/base.html from other app templates

## Testing
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6862d916fd88832486c94b4b269e5179