### PR TITLE
Fix URL namespaces for views and templates

### DIFF
--- a/apps/clientes/templates/clientes/listar.html
+++ b/apps/clientes/templates/clientes/listar.html
@@ -1,11 +1,11 @@
 {% extends 'core/base.html' %}
 {% block content %}
 <h2>Clientes Cadastrados</h2>
-<a href="{% url 'cadastrar_cliente' %}" class="btn btn-success">Novo Cliente</a>
+<a href="{% url 'clientes:cadastrar_cliente' %}" class="btn btn-success">Novo Cliente</a>
 <ul>
   {% for cliente in clientes %}
     <li>
-      <a href="{% url 'visualizar_cliente' cliente.id %}">{{ cliente.nome }}</a>
+      <a href="{% url 'clientes:visualizar_cliente' cliente.id %}">{{ cliente.nome }}</a>
     </li>
   {% endfor %}
 </ul>

--- a/apps/clientes/templates/clientes/visualizar.html
+++ b/apps/clientes/templates/clientes/visualizar.html
@@ -12,5 +12,5 @@
     </li>
   {% endfor %}
 </ul>
-<a href="{% url 'listar_clientes' %}">Voltar</a>
+<a href="{% url 'clientes:listar_clientes' %}">Voltar</a>
 {% endblock %}

--- a/apps/clientes/views.py
+++ b/apps/clientes/views.py
@@ -17,7 +17,7 @@ def cadastrar_cliente(request):
         for arquivo in arquivos[:10]:
             Documento.objects.create(cliente=cliente, arquivo=arquivo, nome=arquivo.name)
 
-        return redirect('listar_clientes')
+        return redirect('clientes:listar_clientes')
 
     return render(request, 'clientes/cadastrar.html')
 

--- a/apps/financeiro/templates/financeiro/listar.html
+++ b/apps/financeiro/templates/financeiro/listar.html
@@ -1,7 +1,7 @@
 {% extends 'core/base.html' %}
 {% block content %}
 <h2>Contas a Pagar e Receber</h2>
-<a href="{% url 'cadastrar_conta' %}" class="btn btn-primary">Nova Conta</a>
+<a href="{% url 'financeiro:cadastrar_conta' %}" class="btn btn-primary">Nova Conta</a>
 <ul>
   {% for conta in contas %}
     <li>

--- a/apps/financeiro/views.py
+++ b/apps/financeiro/views.py
@@ -13,5 +13,5 @@ def cadastrar_conta(request):
         vencimento = request.POST.get('vencimento')
         tipo = request.POST.get('tipo')
         Conta.objects.create(descricao=descricao, valor=valor, vencimento=vencimento, tipo=tipo)
-        return redirect('listar_contas')
+        return redirect('financeiro:listar_contas')
     return render(request, 'financeiro/cadastrar.html')


### PR DESCRIPTION
## Summary
- use namespaced redirects in views
- update templates to use namespaced URLs

## Testing
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6862db4a1d3c8324a346a204665a9ac6