### PR TITLE
Fix navigation and media handling

### DIFF
--- a/apps/core/templates/core/base.html
+++ b/apps/core/templates/core/base.html
@@ -9,7 +9,7 @@
   <h1 class="mb-4">RL Construções Elétricas</h1>
   <nav class="mb-4">
     <a href="{% url 'clientes:listar_clientes' %}" class="btn btn-outline-dark">Clientes</a>
-    <a href="/financeiro/" class="btn btn-outline-dark">Financeiro</a>
+    <a href="{% url 'financeiro:listar_contas' %}" class="btn btn-outline-dark">Financeiro</a>
   </nav>
   {% block content %}{% endblock %}
 </body>

--- a/setup/settings.py
+++ b/setup/settings.py
@@ -110,6 +110,10 @@ USE_TZ = True
 
 STATIC_URL = 'static/'
 
+# Configuracao para arquivos de midia enviados pelos usuarios
+MEDIA_URL = '/media/'
+MEDIA_ROOT = BASE_DIR / 'media'
+
 # Default primary key field type
 # https://docs.djangoproject.com/en/5.2/ref/settings/#default-auto-field
 

--- a/setup/urls.py
+++ b/setup/urls.py
@@ -9,3 +9,6 @@ urlpatterns = [
     path('clientes/', include(('apps.clientes.urls', 'clientes'), namespace='clientes')),
     path('', include(('apps.core.urls', 'core'), namespace='core')),
 ]
+
+if settings.DEBUG:
+    urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)


### PR DESCRIPTION
## Summary
- allow referencing uploaded media files
- serve uploaded media in debug mode
- use named URL for Financeiro link

## Testing
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6863b9f91fc88324a5a9acbbeccb56a4