### PR TITLE
Add estoque links to navigation and home

### DIFF
--- a/apps/core/templates/core/base.html
+++ b/apps/core/templates/core/base.html
@@ -231,6 +231,7 @@
         <nav>
             <a href="{% url 'core:home' %}">Início</a>
             <a href="{% url 'clientes:cliente_list' %}">Clientes</a>
+            <a href="{% url 'estoque:produto_list' %}">Estoque</a>
             <a href="{% url 'financeiro:contas_pagar' %}">Contas a Pagar</a>
             <a href="{% url 'financeiro:contas_receber' %}">Contas a Receber</a>
             <a href="{% url 'financeiro:contas_alerta' %}">Contas do Dia</a>

--- a/apps/core/templates/core/home.html
+++ b/apps/core/templates/core/home.html
@@ -101,6 +101,7 @@
 
         <div class="home-buttons">
             <a href="{% url 'clientes:cliente_list' %}" class="btn-laranja">Gerenciar Clientes</a>
+            <a href="{% url 'estoque:produto_list' %}" class="btn-laranja">Estoque</a>
             <a href="{% url 'financeiro:contas_pagar' %}" class="btn-laranja">Contas a Pagar</a>
             <a href="{% url 'financeiro:contas_receber' %}" class="btn-verde">Contas a Receber</a>
             <a href="{% url 'financeiro:contas_alerta' %}" class="btn-azul">Contas do Dia</a>


### PR DESCRIPTION
## Summary
- include Estoque in top navigation menu
- add Estoque button on home page

## Testing
- `python manage.py check`
- `python manage.py test` *(fails: TypeError: can only concatenate str (not "NoneType") to str)*

------
https://chatgpt.com/codex/tasks/task_e_68a9e9f99df083248b84f5f8f3d83709