### PR TITLE
Fix product listing by iterating over page_obj

### DIFF
--- a/apps/estoque/templates/estoque/produto_list.html
+++ b/apps/estoque/templates/estoque/produto_list.html
@@ -30,7 +30,7 @@
             </tr>
           </thead>
           <tbody>
-            {% for produto in produtos %}
+            {% for produto in page_obj %}
               <tr>
                 <td>{{ produto.nome }}</td>
                 <td class="text-muted">{{ produto.descricao }}</td>


### PR DESCRIPTION
## Summary
- ensure product list template iterates over paginated results

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68aa5502ca3c8324a92ae5792b232507