### PR TITLE
Add product deletion UX to inventory

### DIFF
--- a/apps/estoque/templates/estoque/produto_confirm_delete.html
+++ b/apps/estoque/templates/estoque/produto_confirm_delete.html
@@ -1,0 +1,21 @@
+{% extends 'core/base.html' %}
+
+{% block content %}
+<div class="container py-5">
+  <div class="card mx-auto" style="max-width:500px; background:#1e1e1e; border:1px solid #2a2a2a;">
+    <div class="card-body text-center text-light">
+      <h4 class="mb-3" style="color:#C8A951;">Excluir Produto</h4>
+      <p>Tem certeza que deseja excluir o produto <strong>{{ produto.nome }}</strong>?</p>
+      <form method="post" class="d-flex justify-content-center gap-2 mt-3">
+        {% csrf_token %}
+        <a href="{% url 'estoque:produto_list' %}" class="btn btn-secondary">
+          <i class="bi bi-x-circle"></i> Cancelar
+        </a>
+        <button type="submit" class="btn btn-danger">
+          <i class="bi bi-trash"></i> Excluir
+        </button>
+      </form>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/apps/estoque/templates/estoque/produto_list.html
+++ b/apps/estoque/templates/estoque/produto_list.html
@@ -18,6 +18,15 @@
     </a>
   </div>
 
+  {% if messages %}
+    {% for message in messages %}
+      <div class="alert alert-success alert-dismissible fade show" role="alert">
+        {{ message }}
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+      </div>
+    {% endfor %}
+  {% endif %}
+
   <div class="card" style="background:#1e1e1e; border:1px solid #2a2a2a;">
     <div class="card-body p-0">
       <div class="table-responsive">
@@ -27,6 +36,7 @@
               <th>Nome</th>
               <th>Descrição</th>
               <th class="text-center">Quantidade</th>
+              <th class="text-center">Ações</th>
             </tr>
           </thead>
           <tbody>
@@ -35,10 +45,18 @@
                 <td>{{ produto.nome }}</td>
                 <td class="text-muted">{{ produto.descricao }}</td>
                 <td class="text-center fw-semibold">{{ produto.quantidade }}</td>
+                <td class="text-center">
+                  <a href="{% url 'estoque:produto_update' produto.pk %}" class="btn btn-sm btn-outline-warning" title="Editar">
+                    <i class="bi bi-pencil"></i>
+                  </a>
+                  <a href="{% url 'estoque:produto_delete' produto.pk %}" class="btn btn-sm btn-outline-danger" title="Excluir">
+                    <i class="bi bi-trash"></i>
+                  </a>
+                </td>
               </tr>
             {% empty %}
               <tr>
-                <td colspan="3" class="text-center py-4 text-muted">Nenhum produto cadastrado.</td>
+                <td colspan="4" class="text-center py-4 text-muted">Nenhum produto cadastrado.</td>
               </tr>
             {% endfor %}
           </tbody>


### PR DESCRIPTION
## Summary
- show success messages and action buttons on product list
- add confirmation page to delete products

## Testing
- `python manage.py test` *(fails: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68aa56371bbc8324bee04608923cb4bf